### PR TITLE
Fix : restore notification toast class from functional

### DIFF
--- a/packages/notifications-toast/src/NotificationsToast.js
+++ b/packages/notifications-toast/src/NotificationsToast.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { css, cx } from "emotion";
 import IconButton from "@hig/icon-button";
@@ -12,11 +12,50 @@ import { STATUS_ICONS, AVAILABLE_STATUSES } from "./statuses";
 
 import stylesheet from "./NotificationsToast.stylesheet";
 
-const NotificationsToast = props => {
-  const _renderImage = (themeData, metadata) => {
-    const { showStatusIcon, image, status, ...otherProps } = props;
+export default class NotificationsToast extends Component {
+  static propTypes = {
+    /**
+     * Message content for the Toast. It's recommended to keep the content to no more than 20 words.
+     */
+    children: PropTypes.node,
+    /**
+     * An Avatar or Thumbnail to precede the notification content.
+     * If an image is provided and showStatusIcon is true, the image will take priority.
+     */
+    image: PropTypes.node,
+    /**
+     * Function to call when Toast is dismissed
+     */
+    onDismiss: PropTypes.func,
+    /**
+     * The tooltip text shown for the close icon
+     */
+    onDismissTitle: PropTypes.string,
+    /**
+     * Indicate whether to show the icon associated with the provided status.
+     * An icon will not be shown for a null status.
+     */
+    showStatusIcon: PropTypes.bool,
+    /**
+     * Indicates the style of toast notification
+     */
+    status: PropTypes.oneOf(AVAILABLE_STATUSES),
+    /**
+     * Function to modify the component's styles
+     */
+    stylesheet: PropTypes.func
+  };
+
+  static defaultProps = {
+    onDismissTitle: "Dismiss",
+    showStatusIcon: true,
+    status: "primary"
+  };
+
+  _renderImage = (themeData, metadata) => {
+    const { showStatusIcon, image, status, ...otherProps } = this.props;
     const { className } = otherProps;
-    const styles = stylesheet(props, themeData);
+    const styles = stylesheet(this.props, themeData);
     const iconFill =
       status === "primary"
         ? themeData["basics.colors.primary.autodeskBlue.500"]
@@ -56,128 +95,87 @@ const NotificationsToast = props => {
     return null;
   };
 
-  return (
-    <ThemeContext.Consumer>
-      {({ resolvedRoles, metadata }) => {
-        const {
-          onDismissTitle,
-          status,
-          stylesheet: customStylesheet,
-          ...otherProps
-        } = props;
-        const { className } = otherProps;
-        const styles = stylesheet(
-          { status, stylesheet: customStylesheet },
-          resolvedRoles
-        );
-        const toastBodyClassName = createCustomClassNames(
-          className,
-          "toast-body"
-        );
-        const toastMessageClassName = createCustomClassNames(
-          className,
-          "toast-message"
-        );
-        const toastDismissClassName = createCustomClassNames(
-          className,
-          "toast-dismiss"
-        );
-        const toastTypographyClassName = createCustomClassNames(
-          className,
-          "toast-typography"
-        );
-        const toastIconButtonClassName = createCustomClassNames(
-          className,
-          "toast-icon-button"
-        );
-        const CloseIcon =
-          metadata.densityId === "medium-density" ? CloseSUI : CloseXsUI;
+  render() {
+    return (
+      <ThemeContext.Consumer>
+        {({ resolvedRoles, metadata }) => {
+          const {
+            onDismissTitle,
+            status,
+            stylesheet: customStylesheet,
+            ...otherProps
+          } = this.props;
+          const { className } = otherProps;
+          const styles = stylesheet(
+            { status, stylesheet: customStylesheet },
+            resolvedRoles
+          );
+          const toastBodyClassName = createCustomClassNames(
+            className,
+            "toast-body"
+          );
+          const toastMessageClassName = createCustomClassNames(
+            className,
+            "toast-message"
+          );
+          const toastDismissClassName = createCustomClassNames(
+            className,
+            "toast-dismiss"
+          );
+          const toastTypographyClassName = createCustomClassNames(
+            className,
+            "toast-typography"
+          );
+          const toastIconButtonClassName = createCustomClassNames(
+            className,
+            "toast-icon-button"
+          );
+          const CloseIcon =
+            metadata.densityId === "medium-density" ? CloseSUI : CloseXsUI;
 
-        return (
-          <div className={cx([css(styles.toast), className])}>
-            {_renderImage(resolvedRoles, metadata)}
-            <div className={cx([css(styles.toastBody), toastBodyClassName])}>
-              <div
-                className={cx([
-                  css(styles.toastMessage),
-                  toastMessageClassName
-                ])}
-              >
-                <RichText>
-                  <Typography
-                    style={{
-                      fontSize: "12px",
-                      maxWidth: "220px",
-                      textOverflow: "ellipsis",
-                      overflow: "hidden"
-                    }}
-                    className={toastTypographyClassName}
-                  >
-                    {props.children}
-                  </Typography>
-                </RichText>
+          return (
+            <div className={cx([css(styles.toast), className])}>
+              {this._renderImage(resolvedRoles, metadata)}
+              <div className={cx([css(styles.toastBody), toastBodyClassName])}>
                 <div
                   className={cx([
-                    css(styles.toastDismiss),
-                    toastDismissClassName
+                    css(styles.toastMessage),
+                    toastMessageClassName
                   ])}
                 >
-                  <IconButton
-                    title={onDismissTitle}
-                    icon={<CloseIcon />}
-                    type="transparent"
-                    onClick={props.onDismiss}
-                    className={toastIconButtonClassName}
-                  />
+                  <RichText>
+                    <Typography
+                      style={{
+                        fontSize: "12px",
+                        maxWidth: "220px",
+                        textOverflow: "ellipsis",
+                        overflow: "hidden"
+                      }}
+                      className={toastTypographyClassName}
+                    >
+                      {this.props.children}
+                    </Typography>
+                  </RichText>
+                  <div
+                    className={cx([
+                      css(styles.toastDismiss),
+                      toastDismissClassName
+                    ])}
+                  >
+                    <IconButton
+                      title={onDismissTitle}
+                      icon={<CloseIcon />}
+                      type="transparent"
+                      onClick={this.props.onDismiss}
+                      className={toastIconButtonClassName}
+                    />
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        );
-      }}
-    </ThemeContext.Consumer>
-  );
-};
-
-NotificationsToast.displayName = "NotificationsToast";
-
-NotificationsToast.propTypes = {
-  /**
-   * Message content for the Toast. It's recommended to keep the content to no more than 20 words.
-   */
-  children: PropTypes.node,
-  /**
-   * An Avatar or Thumbnail to precede the notification content.
-   * If an image is provided and showStatusIcon is true, the image will take priority.
-   */
-  image: PropTypes.node,
-  /**
-   * Function to call when Toast is dismissed
-   */
-  onDismiss: PropTypes.func,
-  /**
-   * The tooltip text shown for the close icon
-   */
-  onDismissTitle: PropTypes.string,
-  /**
-   * Indicate whether to show the icon associated with the provided status.
-   * An icon will not be shown for a null status.
-   */
-  showStatusIcon: PropTypes.bool,
-  /**
-   * Indicates the style of toast notification
-   */
-  status: PropTypes.oneOf(AVAILABLE_STATUSES),
-  /**
-   * Function to modify the component's styles
-   */
-  stylesheet: PropTypes.func
-};
-
-NotificationsToast.defaultProps = {
-  onDismissTitle: "Dismiss",
-  showStatusIcon: true,
-  status: "primary"
-};
-
-export default NotificationsToast;
+          );
+        }}
+      </ThemeContext.Consumer>
+    );
+  }
+}

--- a/packages/notifications-toast/src/NotificationsToastList/NotificationsToastList.js
+++ b/packages/notifications-toast/src/NotificationsToastList/NotificationsToastList.js
@@ -9,33 +9,35 @@ import stylesheet from "./NotificationsToastList.stylesheet";
 
 const MAX_TOASTS_ONSCREEN = 3;
 
-const NotificationsToastList = props => {
-  const {
-    children,
-    placement,
-    stylesheet: customStylesheet,
-    ...otherProps
-  } = props;
-  const { className } = otherProps;
-  const keyedChildren = React.Children.toArray(children);
-  const styles = stylesheet(props);
-  const toastListClassName = createCustomClassNames(className, "toast-list");
+export default class NotificationsToastList extends React.Component {
+  static AVAILABLE_PLACEMENTS = AVAILABLE_PLACEMENTS;
+  static placements = placements;
 
-  return (
-    <div className={cx([css(styles.toastListWrapper), className])}>
-      <NotificationsToastListAnimator
-        placement={placement}
-        stylesheet={customStylesheet}
-        className={toastListClassName}
-      >
-        {keyedChildren.slice(0, MAX_TOASTS_ONSCREEN)}
-      </NotificationsToastListAnimator>
-    </div>
-  );
-};
+  render() {
+    const {
+      children,
+      placement,
+      stylesheet: customStylesheet,
+      ...otherProps
+    } = this.props;
+    const { className } = otherProps;
+    const keyedChildren = React.Children.toArray(children);
+    const styles = stylesheet(this.props);
+    const toastListClassName = createCustomClassNames(className, "toast-list");
 
-NotificationsToastList.AVAILABLE_PLACEMENTS = AVAILABLE_PLACEMENTS;
-NotificationsToastList.placements = placements;
+    return (
+      <div className={cx([css(styles.toastListWrapper), className])}>
+        <NotificationsToastListAnimator
+          placement={placement}
+          stylesheet={customStylesheet}
+          className={toastListClassName}
+        >
+          {keyedChildren.slice(0, MAX_TOASTS_ONSCREEN)}
+        </NotificationsToastListAnimator>
+      </div>
+    );
+  }
+}
 
 NotificationsToastList.propTypes = {
   /**
@@ -53,5 +55,3 @@ NotificationsToastList.propTypes = {
    */
   stylesheet: PropTypes.func
 };
-
-export default NotificationsToastList;

--- a/packages/notifications-toast/src/NotificationsToastList/NotificationsToastListAnimator/NotificationsToastListAnimator.js
+++ b/packages/notifications-toast/src/NotificationsToastList/NotificationsToastListAnimator/NotificationsToastListAnimator.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { css, cx } from "emotion";
 import FlipMove from "react-flip-move";
@@ -17,37 +17,37 @@ const onScreenStyles = () => ({
   transform: ""
 });
 
-const NotificationsToastListAnimator = props => {
-  const { children, ...otherProps } = props;
-  const { className } = otherProps;
-  const styles = stylesheet(props);
+export default class NotificationsToastListAnimator extends Component {
+  render() {
+    const { children, ...otherProps } = this.props;
+    const { className } = otherProps;
+    const styles = stylesheet(this.props);
 
-  const enterAnimation = {
-    from: offScreenStyles(props),
-    to: onScreenStyles()
-  };
+    const enterAnimation = {
+      from: offScreenStyles(this.props),
+      to: onScreenStyles()
+    };
 
-  const leaveAnimation = {
-    from: onScreenStyles(),
-    to: offScreenStyles(props)
-  };
+    const leaveAnimation = {
+      from: onScreenStyles(),
+      to: offScreenStyles(this.props)
+    };
 
-  return (
-    <FlipMove
-      className={cx([css(styles.toastList), className])}
-      duration={_ANIMATION_DURATION}
-      staggerDelayBy={_ANIMATION_STAGGER_DELAY_BY}
-      easing="ease-out"
-      appearAnimation={enterAnimation}
-      enterAnimation={enterAnimation}
-      leaveAnimation={leaveAnimation}
-    >
-      {children}
-    </FlipMove>
-  );
-};
-
-NotificationsToastListAnimator.displayName = "NotificationsToastListAnimator";
+    return (
+      <FlipMove
+        className={cx([css(styles.toastList), className])}
+        duration={_ANIMATION_DURATION}
+        staggerDelayBy={_ANIMATION_STAGGER_DELAY_BY}
+        easing="ease-out"
+        appearAnimation={enterAnimation}
+        enterAnimation={enterAnimation}
+        leaveAnimation={leaveAnimation}
+      >
+        {children}
+      </FlipMove>
+    );
+  }
+}
 
 NotificationsToastListAnimator.propTypes = {
   /**
@@ -55,5 +55,3 @@ NotificationsToastListAnimator.propTypes = {
    */
   children: PropTypes.node
 };
-
-export default NotificationsToastListAnimator;


### PR DESCRIPTION
Issue affects to : Notification Toast Component, restore the old version ( class) from functional because the library **FlipMove** is actually deprecated and not working with functional components ( ref : https://www.npmjs.com/package/react-flip-move) 
