### PR TITLE
fix: add validation render Element

### DIFF
--- a/packages/surface/src/Surface.js
+++ b/packages/surface/src/Surface.js
@@ -41,9 +41,11 @@ const Surface = props => {
         const Element = tagName;
 
         return (
-          <Element className={cx(css(styles.surface), className)}>
-            {children}
-          </Element>
+          Element && (
+            <Element className={cx(css(styles.surface), className)}>
+              {children}
+            </Element>
+          )
         );
       }}
     </ThemeContext.Consumer>


### PR DESCRIPTION
Issue affecs to Surface:
When you change the **tagName** and you get **blank** value doesnt work the prop update , so we need improve the validation of the tag before the render in the DOM