### PR TITLE
fix: Added animation support for visible prop

### DIFF
--- a/packages/banner/src/BannerAnimator/BannerAnimator.js
+++ b/packages/banner/src/BannerAnimator/BannerAnimator.js
@@ -105,7 +105,7 @@ const BannerAnimator = props => {
   useEffect(
     () => {
       const { isVisible } = props;
-      
+
       if (!status) {
         return isVisible
           ? endExpand(setState)
@@ -128,7 +128,7 @@ const BannerAnimator = props => {
     [props]
   );
 
-  function usePreviousStatus(value){
+  function usePreviousStatus(value) {
     const ref = useRef(null);
     useEffect(() => {
       ref.current = value;
@@ -140,8 +140,9 @@ const BannerAnimator = props => {
 
   useEffect(
     () => {
-      const expandStatuses = prevStatus === statuses.COLLAPSED && status === statuses.EXPANDING ||
-      prevStatus === statuses.COLLAPSING && status === statuses.EXPANDING; 
+      const expandStatuses =
+        (prevStatus === statuses.COLLAPSED && status === statuses.EXPANDING) ||
+        (prevStatus === statuses.COLLAPSING && status === statuses.EXPANDING);
 
       if (prevStatus === statuses.EXPANDED && status === statuses.COLLAPSING) {
         collapseFromExpanded();
@@ -154,9 +155,8 @@ const BannerAnimator = props => {
       if (prevStatus === statuses.EXPANDING && status === statuses.COLLAPSING) {
         collapse();
       }
-     
     },
-    [props,prevStatus, status]
+    [props, prevStatus, status]
   );
 
   const { children: renderChildren } = props;

--- a/packages/banner/src/BannerAnimator/BannerAnimator.js
+++ b/packages/banner/src/BannerAnimator/BannerAnimator.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 
 import { positions, AVAILABLE_POSITIONS } from "./positions";
@@ -105,7 +105,7 @@ const BannerAnimator = props => {
   useEffect(
     () => {
       const { isVisible } = props;
-
+      
       if (!status) {
         return isVisible
           ? endExpand(setState)
@@ -115,10 +115,10 @@ const BannerAnimator = props => {
       switch (status) {
         case statuses.COLLAPSED:
         case statuses.COLLAPSING:
-          return isVisible ? startExpand() : null;
+          return isVisible ? startExpand(setState) : null;
         case statuses.EXPANDED:
         case statuses.EXPANDING:
-          return isVisible ? null : startCollapse();
+          return isVisible ? null : startCollapse(setState);
         default:
           // eslint-disable-next-line no-console
           console.warn("Invalid status", { status });
@@ -128,23 +128,35 @@ const BannerAnimator = props => {
     [props]
   );
 
+  function usePreviousStatus(value){
+    const ref = useRef(null);
+    useEffect(() => {
+      ref.current = value;
+    });
+    return ref.current;
+  }
+
+  const prevStatus = usePreviousStatus(status);
+
   useEffect(
     () => {
-      const { status: prevStatus } = props;
+      const expandStatuses = prevStatus === statuses.COLLAPSED && status === statuses.EXPANDING ||
+      prevStatus === statuses.COLLAPSING && status === statuses.EXPANDING; 
 
       if (prevStatus === statuses.EXPANDED && status === statuses.COLLAPSING) {
         collapseFromExpanded();
         return;
       }
-      if (prevStatus === statuses.COLLAPSING && status === statuses.EXPANDING) {
+      if (expandStatuses) {
         expand();
         return;
       }
       if (prevStatus === statuses.EXPANDING && status === statuses.COLLAPSING) {
         collapse();
       }
+     
     },
-    [props]
+    [props,prevStatus, status]
   );
 
   const { children: renderChildren } = props;

--- a/packages/banner/src/BannerAnimator/updaters.js
+++ b/packages/banner/src/BannerAnimator/updaters.js
@@ -37,7 +37,7 @@ function getParams(prevState = {}, props = {}) {
 /** @type {BannerAnimatorUpdater} */
 export function startExpand(setState) {
   const { setStatus } = setState;
-  
+
   setStatus(statuses.EXPANDING);
 }
 

--- a/packages/banner/src/BannerAnimator/updaters.js
+++ b/packages/banner/src/BannerAnimator/updaters.js
@@ -35,17 +35,17 @@ function getParams(prevState = {}, props = {}) {
 }
 
 /** @type {BannerAnimatorUpdater} */
-export function startExpand() {
-  return {
-    status: statuses.EXPANDING
-  };
+export function startExpand(setState) {
+  const { setStatus } = setState;
+  
+  setStatus(statuses.EXPANDING);
 }
 
 /** @type {BannerAnimatorUpdater} */
-export function startCollapse() {
-  return {
-    status: statuses.COLLAPSING
-  };
+export function startCollapse(setState) {
+  const { setStatus } = setState;
+
+  setStatus(statuses.COLLAPSING);
 }
 
 /** @type {BannerAnimatorUpdater} */


### PR DESCRIPTION
The issue affects Banner component

Problem:
- When you activate the "visible" prop, It won´t do anything. It should appear or disappear with an animation.

Fix:
- Pass a function to save status to updaters startCollapse and startExpand on updaters.js.
- Added usePreviousStatus hook to save previous status state and follow component logic.
- Pass a function to save status to updaters switch on BannerAnimator.js.
- Added new validation to collapse Banner after the visible is disabled.
