### PR TITLE
HIG1-24: Skip unit testing 

### DIFF
--- a/packages/input/src/Input.test.js
+++ b/packages/input/src/Input.test.js
@@ -124,8 +124,7 @@ describe("Input", () => {
     expect(wrapper.find("input").hasClass(`${className}__input`)).toBe(true);
   });
 
-  /*
-  it("passes down the inputRef", () => {
+  it.skip("passes down the inputRef", () => {
     let inputRef;
 
     function setInputRef(element) {
@@ -136,5 +135,4 @@ describe("Input", () => {
       mount(<Input inputRef={setInputRef} />).containsMatchingElement(inputRef)
     ).toBe(true);
   });
-  */
 });

--- a/packages/menu/src/Option.test.js
+++ b/packages/menu/src/Option.test.js
@@ -113,7 +113,7 @@ describe("menu/Option", () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it("passes down the optionRef", () => {
+  it.skip("passes down the optionRef", () => {
     let optionEl = null;
     const setOptionEl = el => {
       optionEl = el;
@@ -127,8 +127,7 @@ describe("menu/Option", () => {
         <Option id="option-3">Option 3</Option>
       </Menu>
     );
-    if (optionEl) {
-      expect(mount(wrapper).matchesElement(optionEl)).toBeTruthy();
-    }
+
+    expect(mount(wrapper).containsMatchingElement(optionEl)).toBe(true);
   });
 });


### PR DESCRIPTION
Issue affects to Option and Input component
According Stacey's suggestion we need to restore these unit test to original version , and skip it , the reasson is for this migration the old enzyme version is failed , so i updated to v3, some functions were deprecated , but in this particular case the behavior ref is not working correctly
That happens in Option Input , for the next release we'll solved this tech debt 
