### PR TITLE
fix: props collapsed is not passed correctly

### DIFF
--- a/packages/accordion/src/Accordion.js
+++ b/packages/accordion/src/Accordion.js
@@ -108,7 +108,7 @@ const Accordion = props => {
               )}
             </ControlBehavior>
             <ContentPresenter
-              collapsed={collapsed}
+              collapsed={isCollapsed()}
               stylesheet={customStylesheet}
               className={className}
             >


### PR DESCRIPTION
This issue affects to Accordion component:
The props **collapsed** was not passed correctly 