### PR TITLE
HIG1-9 : onmouseover not working flyout

### DIFF
--- a/packages/flyout/src/behaviors/DelayedHoverBehavior.js
+++ b/packages/flyout/src/behaviors/DelayedHoverBehavior.js
@@ -5,12 +5,11 @@ const HoverBehavior = props => {
   const { openOnHoverDelay, onMouseEnter } = props;
   const [hasHover, setHasHover] = useState(false);
 
-  const focusTimeout = event => {
+  const focusTimeout = event =>
     setTimeout(() => {
       setHasHover(true);
       onMouseEnter(event);
     }, openOnHoverDelay);
-  };
 
   const handleFocus = event => {
     if (onMouseEnter) {


### PR DESCRIPTION
This issue affects to Flyout component:
When you enable **onOnHover** and you go outside the children is not working correctly 